### PR TITLE
Update WSSE example code to properly encode nonce in auth header

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ secret "secret": </p>
     generated_digest = b64encode(hashlib.sha256(nonce + created + password).digest())
     headers = {
         'Authorization': 'WSSE profile="UsernameToken"',
-        'X-WSSE': 'UsernameToken Username="%s", PasswordDigest="%s", Nonce="%s", Created="%s"' % (username, generated_digest, nonce, created)
+        'X-WSSE': 'UsernameToken Username="%s", PasswordDigest="%s", Nonce="%s", Created="%s"' % (username, generated_digest, b64encode(nonce), created)
     }
 
 <h4>Email alibresco@princeton.edu with any questions or concerns</h4>


### PR DESCRIPTION
The example WSSE code is wrong in that the nonce is not encoded; the standard WSSE implementation (and the one used by Tigerbook) encodes the nonce in base64. So, the example should reflect that :) 